### PR TITLE
Exposed Developers Filesystem

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,9 +62,9 @@ module.exports = function(filename, opts) {
                     moduleBody = 'module.exports = ' + JSON.stringify(data) + ';';
                 } else {
                     if (options.autoInjectOptions['verbose']) {
-                        moduleBody = 'var css = ' + JSON.stringify(data) + '; (require("browserify-css")).createStyle(css, { "href": ' + JSON.stringify(href) + '})); module.exports = css;';
+                        moduleBody = 'var css = ' + JSON.stringify(data) + '; (require("browserify-css").createStyle(css, { "href": ' + JSON.stringify(href) + '})); module.exports = css;';
                     } else {
-                        moduleBody = 'var css = ' + JSON.stringify(data) + '; (require("browserify-css")).createStyle(css)); module.exports = css;';
+                        moduleBody = 'var css = ' + JSON.stringify(data) + '; (require("browserify-css").createStyle(css)); module.exports = css;';
                     }
                 }
 

--- a/index.js
+++ b/index.js
@@ -62,9 +62,9 @@ module.exports = function(filename, opts) {
                     moduleBody = 'module.exports = ' + JSON.stringify(data) + ';';
                 } else {
                     if (options.autoInjectOptions['verbose']) {
-                        moduleBody = 'var css = ' + JSON.stringify(data) + '; (require(' + JSON.stringify(__dirname) + ').createStyle(css, { "href": ' + JSON.stringify(href) + '})); module.exports = css;';
+                        moduleBody = 'var css = ' + JSON.stringify(data) + '; (require("browserify-css")).createStyle(css, { "href": ' + JSON.stringify(href) + '})); module.exports = css;';
                     } else {
-                        moduleBody = 'var css = ' + JSON.stringify(data) + '; (require(' + JSON.stringify(__dirname) + ').createStyle(css)); module.exports = css;';
+                        moduleBody = 'var css = ' + JSON.stringify(data) + '; (require("browserify-css")).createStyle(css)); module.exports = css;';
                     }
                 }
 


### PR DESCRIPTION
This may have been a feature rather than an issue before. However, by exposing the direct filepath you are also exposing the Developers filesystem. This may be simply an annoyance at times but could result in something far worse depending on how `/super/secret/the/file/system/is`. 

Whats worse is that anyone using this module may have no idea they are exposing themselves like this. You may keep this if it is indeed a feature, however please notify people the path to the browserify-css module will be fully exposed.

Additionally, this will reduce the amount of arbitrary diffs between two different developers if the browserified result is not ignored