### PR TITLE
Allow disabling of url rebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,13 @@ Default: `./`
 
 An absolute path to resolve relative paths against the project's base directory.
 
+### rebaseUrls
+
+Type: `Boolean`
+Default: `true`
+
+If true, relative paths will be rebased in css files; if false, paths will be unchanged.
+
 ## FAQ 
 ### 1. How do I include CSS files located inside the node_modules folder?
 You can choose one of the following methods to include CSS files located inside the node_modules folder:

--- a/css-transform.js
+++ b/css-transform.js
@@ -25,6 +25,8 @@ var cssTransform = function(options, filename, callback) {
         callback(result);
     });
 
+    var rebaseUrls = options.rebaseUrls;
+
     var rootDir = options.rootDir || '';
     if (isRelativePath(rootDir)) {
         rootDir = path.join(process.cwd(), rootDir);
@@ -118,9 +120,11 @@ var cssTransform = function(options, filename, callback) {
                 parseCSSFile(absFilename);
 
             } else {
-                _.each(rule.declarations, function(declaration) {
-                    declaration.value = rebase(declaration.value);
-                });
+                if (rebaseUrls) {
+                    _.each(rule.declarations, function(declaration) {
+                        declaration.value = rebase(declaration.value);
+                    });
+                }
 
                 var cssText = css.stringify({
                     stylesheet: {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var defaults = {
         'verbose': true
     },
     'rootDir': process.cwd(),
+    'rebaseUrls': true,
     'minify': false,
     'minifyOptions': {
         // Check out a list of CSS minify options at [CleanCSS](https://github.com/jakubpawlowicz/clean-css#how-to-use-clean-css-programmatically).


### PR DESCRIPTION
When working on a project, I'd like to be able to add urls to my css relative to the webroot of my project, but unrelated to file system path where the node module is stored.

I have added a `rebaseUrls` option that meets my needs and suspect there may be other users out there who would also like it. 