### PR TITLE
adding support for deduped node modules

### DIFF
--- a/css-transform.js
+++ b/css-transform.js
@@ -16,7 +16,7 @@ var isRelativePath = function(path) {
 };
 
 var isInNodeModuleDir = function () {
-    return !!process.cwd().match(/node_modules/)
+    return !!process.cwd().match(/node_modules/);
 };
 
 var isNodeModule = function (path) {
@@ -26,7 +26,7 @@ var isNodeModule = function (path) {
 var findNodeModuleDir = function (path) {
     var parts = path.split('/');
     var moduleName = '';
-    if (parts[0] == "node_modules") {
+    if (parts[0] === 'node_modules') {
         moduleName = parts[1];
     }
 
@@ -36,9 +36,9 @@ var findNodeModuleDir = function (path) {
     // move up the chain until we are no longer in a node module
     while(isInNodeModuleDir()) {
         if (fs.exists(process.cwd() + '/' + moduleName)) {
-            var path = process.cwd() + '/' + moduleName;
+            var finalPath = process.cwd() + '/' + moduleName;
             process.chdir(startingDirectory);
-            return path;
+            return finalPath;
         }
         process.chdir('../');
     }

--- a/css-transform.js
+++ b/css-transform.js
@@ -23,7 +23,7 @@ var isNodeModule = function (path) {
     return /^node_modules/.test(path);
 };
 
-var findNodeModuleDir = function (path) {
+var findNodeModuleDir = function (dirname, path) {
     var parts = path.split('/');
     var moduleName = '';
     if (parts[0] === 'node_modules') {
@@ -31,11 +31,11 @@ var findNodeModuleDir = function (path) {
     }
 
     var startingDirectory = process.cwd();
-    process.chdir('node_modules');
+    process.chdir(dirname + '/node_modules');
 
     // move up the chain until we are no longer in a node module
     while(isInNodeModuleDir()) {
-        if (fs.exists(process.cwd() + '/' + moduleName)) {
+        if (fs.existsSync(process.cwd() + '/' + moduleName)) {
             var finalPath = process.cwd() + '/' + moduleName;
             process.chdir(startingDirectory);
             return finalPath;
@@ -151,7 +151,7 @@ var cssTransform = function(options, filename, callback) {
                 // if the path starts with node_modules, search up the tree to find the module
                 // in case it was deduped to a higher location in the tree
                 if (isNodeModule(url)) {
-                    absFilename = findNodeModuleDir(url) + '/' + removeNodeModuleInPath(url);
+                    absFilename = findNodeModuleDir(dirname, url) + '/' + removeNodeModuleInPath(url);
                 } else if (isRelativePath(url)) { // relative path
                     absFilename = path.resolve(dirname, url);
                 } else { // absolute path


### PR DESCRIPTION
When using npm3 or when deduping modules such that a given module is moved up the tree to one of its parents node_modules folder, `@import` statements are failing as the target resource is no longer in the modules local node_modules folder.

`@import "node_modules/shared-module/style.css`

This improvement will look up the tree and find the first `shared-module` and use that path to find `style.css`