### PR TITLE
Catch and emit exceptions

### DIFF
--- a/css-transform.js
+++ b/css-transform.js
@@ -197,5 +197,9 @@ module.exports = function(options, filename, callback) {
 
     options = _.defaults(options || {}, defaults);
 
-    cssTransform.call(this, options, filename, callback);
+    try {
+        cssTransform.call(this, options, filename, callback);
+    } catch(err) {
+        this.emit('error', err);
+    }
 };


### PR DESCRIPTION
Exceptions (especially when using something gulp) are extremely cryptic. This resolves that by catching and emitting errors like a good browserify transform.