### PR TITLE
[css-transform.js] 新增inlineImagesOptions属性

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ to:
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAVQAAAHgCAYAAAD6yZXWAAAABmJLR0QA");
 ```
 
-#### inlineImagesOptions
+### inlineImagesOptions
 
 Type: `Object`
 Default:

--- a/README.md
+++ b/README.md
@@ -127,14 +127,15 @@ to:
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAVQAAAHgCAYAAAD6yZXWAAAABmJLR0QA");
 ```
 
-#### `options`
+#### inlineImagesOptions
 
-Using the object syntax you can specify additional options for the inlineImages option:
+Type: `Object`
+Default:
+
 ```js
 {
-    "options": { // maximum size (in bytes) of image file that will be inlined into css file
-        "limit": 0 // 0 means no limit - inline all images
-    }
+    // maximum size (in bytes) of image file that will be inlined into css file
+    "limit": 0 // 0 means no limit - inline all images
 }
 ```
 

--- a/css-transform.js
+++ b/css-transform.js
@@ -58,17 +58,22 @@ var cssTransform = function(options, filename, callback) {
         result = result + data;
         callback(result);
     });
-
+    
     // If inlineImages is not an object but evaluates to true
     // create object with default options
-    if(options.inlineImages && typeof options.inlineImages !== 'object') {
-        options.inlineImages = {
-            options: {
-                limit: 0
-            }
-        };
+    // if(options.inlineImages && typeof options.inlineImages !== 'object') {
+    //     options.inlineImages = {
+    //         options: {
+    //             limit: 0
+    //         }
+    //     };
+    // }
+    if(options.inlineImages && typeof options.inlineImagesOptions !== 'object'){
+        options.inlineImagesOptions = {
+            limit: 0
+        }
     }
-
+    
     var rebaseUrls = options.rebaseUrls;
     var inlineImages = options.inlineImages;
     var rootDir = options.rootDir || '';
@@ -118,7 +123,6 @@ var cssTransform = function(options, filename, callback) {
         };
 
         var inline = function(source) {
-          
             /**
              * Given the contents for an image, returns a data URI string
              * representing the data in that image.
@@ -157,9 +161,9 @@ var cssTransform = function(options, filename, callback) {
                     var mimeType = mime.lookup(localImagePath);
                     if (mimeType.startsWith('image')) {
                         // If a size limit given skip if file larger than limit
-                        if(options.inlineImages.options.limit > 0) {
+                        if(options.inlineImagesOptions.limit > 0) {
                             var stat = fs.statSync(localImagePath);
-                            if(stat.size > options.inlineImages.options.limit) {
+                            if(stat.size > options.inlineImagesOptions.limit) {
                                 continue;
                             }
                         }

--- a/test/index.js
+++ b/test/index.js
@@ -88,12 +88,11 @@ test('processInlineImages in css file with files larger than ', function(t) {
     var outputFile = path.resolve(__dirname, 'fixtures/app.inline-small.css');
 
     cssTransform({
-				inlineImages: {
-            options: {
-                limit: 100000
-						}
-				},
-				rebaseUrls: false
+		inlineImages: true,
+        inlineImagesOptions: {
+            limit: 100000
+        },
+        rebaseUrls: false
     }, inputFile, function(data) {
         t.same(data, fs.readFileSync(outputFile, 'utf-8'));
         t.end();


### PR DESCRIPTION
- 设置"limit"属性失效，在`index.js` 强制转成布尔值造成 
```js
options.inlineImages = bool(options.inlineImages);
```

- 建议，新增inlineImagesOptions
```js
module.exports = {
    "inlineImagesOptions": {
         "limit": 0
     }
}
```