### PR TITLE
fix failing tests - submodule reference doesn't exist

### DIFF
--- a/examples/submodules/app.css
+++ b/examples/submodules/app.css
@@ -1,4 +1,3 @@
 @import "../node_modules/bootstrap/dist/css/bootstrap.css";
-@import "node_modules/jquery-ui/themes/base/theme.css";
 @import "modules/foo/foo.css";
 @import "modules/bar/bar.css";


### PR DESCRIPTION
I don't yet understand why this reference was there, but there a reference to a file in a dependency that this submodule doesn't actually list in its `package.json`.

This fixes the build failure in master and e.g. #63, but should we do this, or should this package somehow handle these errors differently?